### PR TITLE
fix: update deprecated actions/upload-artifact

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -36,7 +36,7 @@ jobs:
         run: flutter build apk --release
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-apk
           path: build/app/outputs/flutter-apk/app-release.apk


### PR DESCRIPTION
This commit updates the `actions/upload-artifact` GitHub Action from the deprecated version `v3` to the current version `v4`. This resolves the error message "This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`."