### PR TITLE
fix: update deprecated actions/upload-artifact and Flutter version

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.10.0' # You can specify a different version here
+          flutter-version: '3.22.0' # You can specify a different version here
           channel: 'stable'
 
       - name: Install Dependencies


### PR DESCRIPTION
This commit updates the `actions/upload-artifact` GitHub Action from the deprecated version `v3` to the current version `v4`. It also updates the Flutter version to a compatible version to resolve the Dart SDK version mismatch. This resolves the error message "This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`."