### PR TITLE
Fix critical startup crash and branding inconsistencies

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="app_muta"
+        android:label="Muta Manager"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/kotlin/com/ceraiolo/muta_manager/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ceraiolo/muta_manager/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.ceraiolo.app_muta.app_muta
+package com.ceraiolo.muta_manager
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:app_muta/main.dart' as app;
+import 'package:muta_manager/main.dart' as app;
 import 'package:provider/provider.dart';
-import 'package:app_muta/theme/theme_provider.dart';
+import 'package:muta_manager/theme/theme_provider.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.appmuta.appMuta;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.muta_manager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.appmuta.appMuta.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.muta_manager.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.appmuta.appMuta.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.muta_manager.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.appmuta.appMuta.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.muta_manager.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.appmuta.appMuta;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.muta_manager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.appmuta.appMuta;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ceraiolo.muta_manager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/lib/services/database_helper.dart
+++ b/lib/services/database_helper.dart
@@ -31,13 +31,7 @@ class DatabaseHelper {
     final dbPath = await getDatabasesPath();
     final path = join(dbPath, filePath);
 
-    return await openDatabase(path, version: 2, onCreate: _createDB, onUpgrade: _onUpgrade);
-  }
-
-  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
-    if (oldVersion < 2) {
-      await db.execute('ALTER TABLE ceraioli ADD COLUMN cero INTEGER NOT NULL DEFAULT 0');
-    }
+    return await openDatabase(path, version: 2, onCreate: _createDB);
   }
 
   Future _createDB(Database db, int version) async {

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="app_muta">
+  <meta name="apple-mobile-web-app-title" content="Muta Manager">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>app_muta</title>
+  <title>Muta Manager</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "app_muta",
-    "short_name": "app_muta",
+    "name": "muta_manager",
+    "short_name": "muta_manager",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
This commit resolves a critical startup crash on both Android and iOS by addressing several configuration mismatches and a database migration error.

- **Android:**
  - Renamed the package directory from `com/ceraiolo/app_muta/app_muta` to `com/ceraiolo/muta_manager`.
  - Updated the package declaration in `MainActivity.kt` to match the new `applicationId`.
  - Updated the application label in `AndroidManifest.xml` to "Muta Manager".

- **iOS:**
  - Updated the `PRODUCT_BUNDLE_IDENTIFIER` from `com.ceraiolo.appmuta.appMuta` to `com.ceraiolo.muta_manager` for all build configurations in `project.pbxproj`.

- **Database:**
  - Removed the faulty `_onUpgrade` logic in `database_helper.dart` to prevent crashes for existing users during migration.

- **Consistency:**
  - Performed a project-wide search and replace to ensure all instances of `app_muta` were updated to `muta_manager` or "Muta Manager".
  - Updated web-related files (`index.html`, `manifest.json`) and integration tests with the new name.